### PR TITLE
cobbler_repos: include --arch in repo edit

### DIFF
--- a/cobbler_deploy/tasks/cobbler_repos.yml
+++ b/cobbler_deploy/tasks/cobbler_repos.yml
@@ -50,6 +50,7 @@
          - repo
          - edit
          - --name={{ item.name }}
+         - --arch={{ item.arch|default('x86_64') }}
          - --mirror={{ item.mirror }}
          - --rpm-list={% if item.rpm_list|default('') is string %}{{ item.rpm_list|default('') }}{% else %}{{ item.rpm_list|join(' ') }}{% endif %}
          - --mirror-locally={{ item.mirror_locally | default('Y') }}


### PR DESCRIPTION
This PR patches the execution of `cobbler repo edit` to include the `--arch` option to allow changing the arch of an existing repo.